### PR TITLE
fix double-tail p-value formula

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -264,7 +264,7 @@ Consider the following two cases:
 
 * $P(X \geq x | H_0)$ for right tail event
 * $P(X \leq x | H_0)$ for left tail event
-* $2 min \{P(X \leq x | H_0), P(X \leq x | H_0)\}$ for double tail event
+* $2 min \{P(X \leq x | H_0), P(X \geq x | H_0)\}$ for double tail event
 
 The p-value is defined as the probability of obtaining a result equal to or more extreme than what was actually observed, under the assumption of hypothesis $H_0$ is true.
 

--- a/index.html
+++ b/index.html
@@ -467,7 +467,7 @@ htest
     <ul>
 <li>\(P(X \geq x | H_0)\) for right tail event</li>
 <li>\(P(X \leq x | H_0)\) for left tail event</li>
-<li>\(2 min \{P(X \leq x | H_0), P(X \leq x | H_0)\}\) for double tail event</li>
+<li>\(2 min \{P(X \leq x | H_0), P(X \geq x | H_0)\}\) for double tail event</li>
 </ul>
 
 <p>The p-value is defined as the probability of obtaining a result equal to or more extreme than what was actually observed, under the assumption of hypothesis \(H_0\) is true.</p>

--- a/index.md
+++ b/index.md
@@ -316,7 +316,7 @@ Consider the following two cases:
 
 * $P(X \geq x | H_0)$ for right tail event
 * $P(X \leq x | H_0)$ for left tail event
-* $2 min \{P(X \leq x | H_0), P(X \leq x | H_0)\}$ for double tail event
+* $2 min \{P(X \leq x | H_0), P(X \geq x | H_0)\}$ for double tail event
 
 The p-value is defined as the probability of obtaining a result equal to or more extreme than what was actually observed, under the assumption of hypothesis $H_0$ is true.
 


### PR DESCRIPTION
I found difference between formulas from a slide and a wiki page about p-value
https://en.wikipedia.org/wiki/P-value#Definition_and_interpretation

so, here is the fix for it
